### PR TITLE
Added support for custom output filenames and temp files in subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# puppeteer-video-recorder
+# puppeteer-video-recorder - Dreamdealer Edit
 [Prerequisites](#Prerequisites "Prerequisites") | [Installation](#Installation "Installation") | [Manual](#Manual "Manual") | [InitOptions](InitOptions.md "InitOptions") | [StartOptions](StartOptions.md "StartOptions") | [FAQ](#FAQ "FAQ")
 
 <p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# puppeteer-video-recorder - Dreamdealer Edit
+# puppeteer-video-recorder
 [Prerequisites](#Prerequisites "Prerequisites") | [Installation](#Installation "Installation") | [Manual](#Manual "Manual") | [InitOptions](InitOptions.md "InitOptions") | [StartOptions](StartOptions.md "StartOptions") | [FAQ](#FAQ "FAQ")
 
 <p>

--- a/handlers/FsHandler.js
+++ b/handlers/FsHandler.js
@@ -3,14 +3,17 @@ const { openSync, closeSync, existsSync } = require('fs');
 const { join } = require('path');
 
 class FsHandler {
-    async init(outputFolder, testName) {
+    async init(outputFolder, videoName) {
         const now = new Date();
         this.outputFolder = outputFolder;
 
+        // get the time to construct a more human readable timestamp in the filename
         const hours = this.addZeroBefore(now.getHours());
         const minutes = this.addZeroBefore(now.getMinutes());
         const seconds = this.addZeroBefore(now.getSeconds());
-        const videofilename = `../${testName}-${hours}:${minutes}:${seconds}.webm`;
+
+        // do not put the video in the test subfolder, but in the root recording folder
+        const videofilename = `../${videoName}-${hours}:${minutes}:${seconds}.webm`;
         
         this.videoFilename = join(this.outputFolder, videofilename);
         this.imagesPath = join(this.outputFolder, 'images');
@@ -24,7 +27,7 @@ class FsHandler {
         return (n < 10 ? '0' : '') + n;
     }
 
-    async clear() {
+    async clearOutputSubFolder() {
         if (await existsSync(this.outputFolder)) {
             await rmdir(this.outputFolder, { recursive: true });
         }

--- a/handlers/FsHandler.js
+++ b/handlers/FsHandler.js
@@ -1,4 +1,4 @@
-const { appendFile, mkdir, rmdir, unlink } = require('fs').promises;
+const { appendFile, mkdir, rmdir } = require('fs').promises;
 const { openSync, closeSync, existsSync } = require('fs');
 const { join } = require('path');
 
@@ -10,7 +10,7 @@ class FsHandler {
         const hours = this.addZeroBefore(now.getHours());
         const minutes = this.addZeroBefore(now.getMinutes());
         const seconds = this.addZeroBefore(now.getSeconds());
-        const videofilename = `${testName.replace(/ /gi, '_').toLowerCase()}-${hours}:${minutes}:${seconds}.webm`;
+        const videofilename = `../${testName}-${hours}:${minutes}:${seconds}.webm`;
         
         this.videoFilename = join(this.outputFolder, videofilename);
         this.imagesPath = join(this.outputFolder, 'images');
@@ -25,11 +25,8 @@ class FsHandler {
     }
 
     async clear() {
-        if (await existsSync(this.imagesPath)) {
-            await rmdir(this.imagesPath, { recursive: true });
-        }
-        if (await existsSync(this.imagesFilename)) {
-            await unlink(this.imagesFilename);
+        if (await existsSync(this.outputFolder)) {
+            await rmdir(this.outputFolder, { recursive: true });
         }
     }
 

--- a/handlers/FsHandler.js
+++ b/handlers/FsHandler.js
@@ -1,16 +1,36 @@
-const { appendFile, mkdir } = require('fs').promises;
+const { appendFile, mkdir, rmdir, unlink } = require('fs').promises;
 const { openSync, closeSync, existsSync } = require('fs');
 const { join } = require('path');
 
 class FsHandler {
-    async init(outputFolder) {
+    async init(outputFolder, testName) {
+        const now = new Date();
         this.outputFolder = outputFolder;
-        this.videoFilename = join(this.outputFolder, Date.now() + '.webm');
+
+        const hours = this.addZeroBefore(now.getHours());
+        const minutes = this.addZeroBefore(now.getMinutes());
+        const seconds = this.addZeroBefore(now.getSeconds());
+        const videofilename = `${testName.replace(/ /gi, '_').toLowerCase()}-${hours}:${minutes}:${seconds}.webm`;
+        
+        this.videoFilename = join(this.outputFolder, videofilename);
         this.imagesPath = join(this.outputFolder, 'images');
         this.imagesFilename = join(this.outputFolder, 'images.txt');
         await this.verifyPathExists(this.outputFolder);
         await this.verifyPathExists(this.imagesPath);   
         await this.verifyPathExists(this.imagesFilename, 'file');
+    }
+
+    addZeroBefore(n) {
+        return (n < 10 ? '0' : '') + n;
+    }
+
+    async clear() {
+        if (await existsSync(this.imagesPath)) {
+            await rmdir(this.imagesPath, { recursive: true });
+        }
+        if (await existsSync(this.imagesFilename)) {
+            await unlink(this.imagesFilename);
+        }
     }
 
     createEmptyFile(filename) {

--- a/handlers/FsHandler.js
+++ b/handlers/FsHandler.js
@@ -3,17 +3,12 @@ const { openSync, closeSync, existsSync } = require('fs');
 const { join } = require('path');
 
 class FsHandler {
-    async init(outputFolder, videoName) {
+    async init(outputFolder, name = Date.now()) {
         const now = new Date();
         this.outputFolder = outputFolder;
 
-        // get the time to construct a more human readable timestamp in the filename
-        const hours = this.addZeroBefore(now.getHours());
-        const minutes = this.addZeroBefore(now.getMinutes());
-        const seconds = this.addZeroBefore(now.getSeconds());
-
         // do not put the video in the test subfolder, but in the root recording folder
-        const videofilename = `../${videoName}-${hours}:${minutes}:${seconds}.webm`;
+        const videofilename = `../${name}.webm`;
         
         this.videoFilename = join(this.outputFolder, videofilename);
         this.imagesPath = join(this.outputFolder, 'images');

--- a/handlers/FsHandler.js
+++ b/handlers/FsHandler.js
@@ -4,7 +4,6 @@ const { join } = require('path');
 
 class FsHandler {
     async init(outputFolder, name = Date.now()) {
-        const now = new Date();
         this.outputFolder = outputFolder;
 
         // do not put the video in the test subfolder, but in the root recording folder
@@ -16,10 +15,6 @@ class FsHandler {
         await this.verifyPathExists(this.outputFolder);
         await this.verifyPathExists(this.imagesPath);   
         await this.verifyPathExists(this.imagesFilename, 'file');
-    }
-
-    addZeroBefore(n) {
-        return (n < 10 ? '0' : '') + n;
     }
 
     async clearOutputSubFolder() {

--- a/index.js
+++ b/index.js
@@ -11,26 +11,40 @@ class PuppeteerVideoRecorder {
     async init(page, outputFolder, testName){
         this.page = page;
         this.outputFolder = outputFolder;
-        await this.fsHandler.init(outputFolder, testName);
+        // replace spaces with underscores and form a name for a sub-folder for each test
+        this.testSubFolder = testName.replace(/ /gi, '_').toLowerCase();
+        // append sub-folder name to output folder to form the full output folder name
+        this.fullOutputFolder = `${this.outputFolder.replace(/\/$/, "")}/${this.testSubFolder}/`;
+        await this.fsHandler.init(this.fullOutputFolder, testName);
         const { imagesPath, imagesFilename, appendToFile } = this.fsHandler;
+        // strip the full output foldername from the filename to prevent FFMPEG throwing errors
         await this.screenshots.init(page, imagesPath, {
-            afterWritingImageFile: (filename) => appendToFile(imagesFilename, `file '${filename.replace(outputFolder,'')}'\n`)
+            afterWritingImageFile: (filename) => appendToFile(imagesFilename, `file '${filename.replace(this.fullOutputFolder,'')}'\n`)
         });
     }
 
+    // start recording images
     start(options = {}) { 
         return this.screenshots.start(options);
     }
-    
+
+    // stop recording and save images as videofile
     async stop () {
     	await this.screenshots.stop();
     	await this.createVideo();
-        await this.fsHandler.clear();
     }
 
+    // stop recording, save video and clear the subfolder with images
+    async stopAndClear () {
+    	await this.screenshots.stop();
+    	await this.createVideo();
+        await this.fsHandler.clearOutputSubFolder();
+    }
+
+    // stop recording, do not save a video and clear all images
     async cancel () {
     	await this.screenshots.stop();
-        await this.fsHandler.clear();
+        await this.fsHandler.clearOutputSubFolder();
     }
 
     get defaultFFMpegCommand() {

--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ class PuppeteerVideoRecorder {
     async init(page, outputFolder, testName){
         this.page = page;
         this.outputFolder = outputFolder;
-        // replace spaces with underscores and form a name for a sub-folder for each test
-        this.testSubFolder = testName.replace(/ /gi, '_').toLowerCase();
+        // if no testName was provided use a timestamp
+        this.testName = testName ? testName : Date.now();
         // append sub-folder name to output folder to form the full output folder name
-        this.fullOutputFolder = `${this.outputFolder.replace(/\/$/, "")}/${this.testSubFolder}/`;
-        await this.fsHandler.init(this.fullOutputFolder, testName);
+        this.fullOutputFolder = `${this.outputFolder.replace(/\/$/, "")}/${this.testName.replace(/ /gi, '_').toLowerCase()}/`;
+        await this.fsHandler.init(this.fullOutputFolder, this.testName);
         const { imagesPath, imagesFilename, appendToFile } = this.fsHandler;
         // strip the full output foldername from the filename to prevent FFMPEG throwing errors
         await this.screenshots.init(page, imagesPath, {
@@ -34,17 +34,14 @@ class PuppeteerVideoRecorder {
     	await this.createVideo();
     }
 
-    // stop recording, save video and clear the subfolder with images
-    async stopAndClear () {
-    	await this.screenshots.stop();
-    	await this.createVideo();
+    // clear the subfolder with images
+    async clear () {
         await this.fsHandler.clearOutputSubFolder();
     }
 
-    // stop recording, do not save a video and clear all images
+    // stop recording, do not save a video
     async cancel () {
     	await this.screenshots.stop();
-        await this.fsHandler.clearOutputSubFolder();
     }
 
     get defaultFFMpegCommand() {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class PuppeteerVideoRecorder {
         await this.fsHandler.clear();
     }
 
-    async stopButDontSaveVideo () {
+    async cancel () {
     	await this.screenshots.stop();
         await this.fsHandler.clear();
     }

--- a/index.js
+++ b/index.js
@@ -8,18 +8,23 @@ class PuppeteerVideoRecorder {
         this.fsHandler = new FsHandler();
     }
 
-    async init(page, outputFolder, testName){
+    async init(page, outputFolder, name = Date.now()){
         this.page = page;
         this.outputFolder = outputFolder;
-        // if no testName was provided use a timestamp
-        this.testName = testName ? testName : Date.now();
+        this.testName = name;
+        
         // append sub-folder name to output folder to form the full output folder name
         this.fullOutputFolder = `${this.outputFolder.replace(/\/$/, "")}/${this.testName.replace(/ /gi, '_').toLowerCase()}/`;
+
         await this.fsHandler.init(this.fullOutputFolder, this.testName);
+        
         const { imagesPath, imagesFilename, appendToFile } = this.fsHandler;
-        // strip the full output foldername from the filename to prevent FFMPEG throwing errors
+        
         await this.screenshots.init(page, imagesPath, {
-            afterWritingImageFile: (filename) => appendToFile(imagesFilename, `file '${filename.replace(this.fullOutputFolder,'')}'\n`)
+            // strip the full output foldername from the filename to prevent FFMPEG throwing errors
+            afterWritingImageFile: (filename) => {
+                appendToFile(imagesFilename, `file 'images${filename.split(imagesPath)[1]}'\n`)
+            }
         });
     }
 


### PR DESCRIPTION
To implement this package in our e2e tests I made some changes:

- Each test recording gets its own subfolder for the images and the images.txt file
- Each recording can get an optional name

This is how we implemented it in our e2e env. It starts a recording for each `it` in a test. When the test succeeds the video is not rendered and the temp dir is cleared. When a test fails, the video is compiled and the temp dir is also cleared. At the end of all tests the `recording/` folder only contains the .webm video files of failed tests.

We then upload these videos together with the test results to slack using a github action.

```
global.it = async function(name, func) {
    return await test(name, async () => {
        const recorder = new PuppeteerVideoRecorder();
        await recorder.init(page, `recording/`, `${name}-${Date.now()}`);
        await recorder.start();

        try {
            await func();
            await recorder.cancel();
            await recorder.clear();
        } catch (error) {
            await recorder.stop();
            await recorder.clear();
            throw error;
        }
    });
};
```

@shaynet10 