### PR TITLE
createVideo does not wait for ffmpeg to finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { FsHandler } = require('./handlers');
 const { exec } = require('child_process');
+const { promisify } = require('util');
 const PuppeteerMassScreenshots = require('puppeteer-mass-screenshots');
 
 class PuppeteerVideoRecorder {
@@ -24,7 +25,7 @@ class PuppeteerVideoRecorder {
     
     async stop () {
     	await this.screenshots.stop();
-    	return this.createVideo();
+    	await this.createVideo();
     }
 
     get defaultFFMpegCommand() {
@@ -39,13 +40,11 @@ class PuppeteerVideoRecorder {
         ].join(' ');
     }
 
-    createVideo(ffmpegCommand = '') {
+    async createVideo(ffmpegCommand = '') {
         const _ffmpegCommand = ffmpegCommand || this.defaultFFMpegCommand;
-        exec(_ffmpegCommand, (error, stdout, stderr) => {
-            if (error) throw new Error(error);
-            console.log(stdout);
-            console.log(stderr);
-        });
+        const { stdout, stderr } = await promisify(exec)(_ffmpegCommand);
+        console.log(stdout);
+        console.log(stderr);
     }
 }
 


### PR DESCRIPTION
A script that loads a page and calls process.exit at the end, creates all the image files, but does not create the video file.

The problem is that stop() returns a Promise that is resolved before ffmpeg has had enough time to complete.